### PR TITLE
Add empty relativePath to spring boot parent in pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,6 +9,7 @@
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
 		<version>1.2.8.RELEASE</version>
+		<relativePath></relativePath>
 	</parent>
 
 	<properties>


### PR DESCRIPTION
Avoids the following warning while building on my machine:

```
[WARNING] 'parent.relativePath' of POM eu.freme:freme-parent:0.2-SNAPSHOT (/Users/anpr/git/freme-project/freme-parent/pom.xml) points at eu.freme:common instead of org.springframework.boot:spring-boot-starter-parent, please verify your project structure @ line 8, column 10
```

Relevant documentation: http://maven.apache.org/ref/3.0.3/maven-model/maven.html#class_parent
